### PR TITLE
Updated timeShiftBufferDepth to be up to spec

### DIFF
--- a/src/ngx_ts_dash.c
+++ b/src/ngx_ts_dash.c
@@ -825,21 +825,9 @@ ngx_ts_dash_update_playlist(ngx_ts_dash_t *dash)
     ngx_ts_dash_format_datetime(avail_start_time, dash->availability_start);
     ngx_ts_dash_format_datetime(pub_time, now);
 
-    /*
-     *                 timeShiftBufferDepth
-     *       ----------------------------------------
-     *      |                                        |
-     * -----///////----------------*-----------------> now
-     *            |                |                 |
-     *             ---------------- -----------------
-     *                 liveDelay     lastSegDuration
-     *           = 2 * minBufferTime
-     *
-     */
-
     min_update = dash->conf->min_seg / 1000;
     min_buftime = dash->conf->min_seg / 1000;
-    buf_depth = 2 * min_buftime + dash->conf->max_seg / 1000 + 1;
+    buf_depth = dash->conf->nseg * min_buftime;
 
     for ( ;; ) {
         ngx_log_debug1(NGX_LOG_DEBUG_CORE, ts->log, 0,


### PR DESCRIPTION
As specified in MPEG-DASH spec, ISO 23009-1:2014, the `@timeShiftBufferDepth` element value should represent the time guaranteed to be available for viewing. This also enables VOD features as well if set properly.

This commit changes the buffer depth to the maximum number of segments multiplied by the minimum buffer time of one segment since that length is guaranteed to exist. 